### PR TITLE
Adding long arguments and updating readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,43 +14,42 @@ pip install -r requirements.txt
 ````
 % ./peering_buddy.py
 usage: peering_buddy.py [-h] [-av ASN] [-ap ASN] [-ar ASN] [-lg PREFIX] [-al ASN] [-as ASN] [-au ASN] [-tm INTEGER] [-ti INTEGER] [-ta INTEGER] [-ao ASN] [-ac ASN] [-pa ASN THRESHOLD PREPEND[y|n]] [-tu ASN] [-gu ASN] [-gd ASN] [-gw [ASN|PREFIX]] [-wi IP]
-                        [-aa ASN] [-ip] [-ai ASN] [-ii ASN] [-gc ASN] [-cc ASN] [-gl] [-b] [-b4] [-b6] [-ba] [-nv]
+                        [-aa ASN] [-ip] [-ai ASN] [-ii ASN] [-gc ASN] [-cc ASN] [-gl] [-bo] [-b4] [-b6] [-ba] [-nv]
 
 Peering Buddy - Helping you dig data from internet for better decisions!
 
 optional arguments:
-  -h, --help            show this help message and exit
-  -av ASN               [RIPE] Check ASN visibility RIPE RIS sensors.
-  -ap ASN               [RIPE] Check ASN announced prefixes to internet.
-  -ar ASN               [RIPE] Check ASN RPKI/ROA validation for announced prefixes.
-  -lg PREFIX            [RIPE] Get prefix using RIPE RIS as Looking Glass.
-  -al ASN               [RIPE] Check AS-Path length overview.
-  -as ASN               [RIPE] Check AS-Path length stripped [no as-prepend].
-  -au ASN               [RIPE] Check AS-Path length unstripped [with as-prepend].
-  -tm INTEGER           [RIPE][as|au] Threshold [>=] to be used with -as and -au for max.
-  -ti INTEGER           [RIPE][as|au] Threshold [>=] to be used with -as and -au for min.
-  -ta INTEGER           [RIPE][as|au] Threshold [>=] to be used with -as and -au for avg.
-  -ao ASN               [RIPE] Check ASN public resources overview.
-  -ac ASN               [RIPE][BGPView][IPInfo] Check ASN announces consistency.
-  -pa ASN THRESHOLD PREPEND[y|n]
-                        [RIPE][BGPView] Check ASN prefixes where as-path length >= threshold.
-  -tu ASN               [RIPE][BGPView] Check ASN upstreams on transient paths.
-  -gu ASN               [BGPView] Get ASN upstreams.
-  -gd ASN               [BGPView] Get ASN downstreams.
-  -gw [ASN|PREFIX]      [BGPView] Get ASN/Prefix whois information.
-  -wi IP                [IPInfo] Get IP whois information.
-  -aa ASN               [PeeringDB][RIPE] Check ASN AS-SET and expand it. Limited to RIPE ASNs.
-  -ip                   [PeeringDB] Get IXPs prefixes.
-  -ai ASN               [PeeringDB] Get ASN information on PeeringDB.
-  -ii ASN               [PeeringDB] Get ASN IPS allocated on IXPs.
-  -gc ASN               [PeeringDB] Get ASN contact.
-  -cc ASN               [PeeringDB] Get IXPs by Country Code [iso-3166-1 alpha-2].
-  -gl                   [Team Cymrus] Check a list of public LookingGlass.
-  -bo                   [Team Cymrus] Get ip4 bogons list.
-  -b4                   [Team Cymrus] Get ip4 full (+unallocated) bogons list.
-  -b6                   [Team Cymrus] Get ip6 full (+unallocated) bogons list.
-  -ba                   [NTT] Get ASN bogons list/examples.
-  -nv                   Remove human-like text to the output.
+  -h, --help                                                                           show this help message and exit
+  -av ASN, --asn-visibility ASN                                                        [RIPE] Check ASN visibility RIPE RIS sensors.
+  -ap ASN, --asn-announced-pfxs ASN                                                    [RIPE] Check ASN announced prefixes to internet.
+  -ar ASN, --asn-roa-validation ASN                                                    [RIPE] Check ASN RPKI/ROA validation for announced prefixes.
+  -lg PREFIX, --looking-glass PREFIX                                                   [RIPE] Get prefix using RIPE RIS as Looking Glass.
+  -al ASN, --aspath-length-overview ASN                                                [RIPE] Check AS-Path length overview.
+  -as ASN, --aspath-lenghth-stripped ASN                                               [RIPE] Check AS-Path length stripped [no as-prepend].
+  -au ASN, --aspath-lenghth-unstripped ASN                                             [RIPE] Check AS-Path length unstripped [with as-prepend].
+  -tm INTEGER, --threshold-max INTEGER                                                 [RIPE][as|au] Threshold [>=] to be used with -as and -au for max.
+  -ti INTEGER, --threshold-min INTEGER                                                 [RIPE][as|au] Threshold [>=] to be used with -as and -au for min.
+  -ta INTEGER, --threshold-avg INTEGER                                                 [RIPE][as|au] Threshold [>=] to be used with -as and -au for avg.
+  -ao ASN, --asn-overview ASN                                                          [RIPE] Check ASN public resources overview.
+  -ac ASN, --asn-announce-consistency ASN                                              [RIPE][BGPView][IPInfo] Check ASN announces consistency.
+  -pa ASN THRESHOLD PREPEND[y|n], --asn-pfxs-aspath-length ASN THRESHOLD PREPEND[y|n]  [RIPE][BGPView] Check ASN prefixes where as-path length >= threshold.
+  -tu ASN, --asn-upstreams-transient ASN                                               [RIPE][BGPView] Check ASN upstreams on transient paths.
+  -gu ASN, --asn-upstreams ASN                                                         [BGPView] Get ASN upstreams.
+  -gd ASN, --asn-downstreams ASN                                                       [BGPView] Get ASN downstreams.
+  -gw [ASN|PREFIX], --whois [ASN|PREFIX]                                               [BGPView] Get ASN/Prefix whois information.
+  -wi IP, --whois-ip IP                                                                [IPInfo] Get IP whois information.
+  -aa ASN, --asset ASN                                                                 [PeeringDB][RIPE] Check ASN AS-SET and expand it. Limited to RIPE ASNs.
+  -ip, --pdb-ixp-pfxs                                                                  [PeeringDB] Get IXPs prefixes.
+  -ai ASN, --pdb-asn-info ASN                                                          [PeeringDB] Get ASN information on PeeringDB.
+  -ii ASN, --pdb-asn-ips ASN                                                           [PeeringDB] Get ASN IPS allocated on IXPs.
+  -gc ASN, --pdb-asn-contact ASN                                                       [PeeringDB] Get ASN contact.
+  -cc ASN, --pdb-ixp-bycc ASN                                                          [PeeringDB] Get IXPs by Country Code [iso-3166-1 alpha-2].
+  -gl, --lgs                                                                           [Team Cymrus] Check a list of public LookingGlass.
+  -bo, --bogons                                                                        [Team Cymrus] Get ip4 bogons list.
+  -b4, --bogons-v4                                                                     [Team Cymrus] Get ip4 full (+unallocated) bogons list.
+  -b6, --bogons-v6                                                                     [Team Cymrus] Get ip6 full (+unallocated) bogons list.
+  -ba, --bogons-asn                                                                    [NTT] Get ASN bogons list/examples.
+  -nv, --non-verbose                                                                   Remove human-like text to the output.
 ````
 
 ## usage examples
@@ -1115,8 +1114,3 @@ Juniper:
 
 ================================================================================
 ````
-
-## todo
-=> Only RIPE AS-SETs are being expanded in the option -aa.
-
-=> Add option for PeeringDB authentication to bypass API rate-limit.

--- a/pbuddy/pbuddy.py
+++ b/pbuddy/pbuddy.py
@@ -12,7 +12,8 @@ import requests
 
 
 class Bcolors:
-    """ ANSI colors class """
+    """ANSI colors class"""
+
     HEADER = "\033[95m"
     OKBLUE = "\033[94m"
     OKGREEN = "\033[92m"
@@ -63,8 +64,11 @@ class PBuddy:
         if response.status_code == 200:
             data = json.loads(response.text)
             result = data["data"]
-            for afi in result['visibility']:
-                visibility_perc = (result['visibility'][afi]['ris_peers_seeing'] / result['visibility'][afi]['total_ris_peers']) * 100
+            for afi in result["visibility"]:
+                visibility_perc = (
+                    result["visibility"][afi]["ris_peers_seeing"]
+                    / result["visibility"][afi]["total_ris_peers"]
+                ) * 100
                 visibility_dict[afi] = visibility_perc
         else:
             print("ERROR | HTTP status != 200")
@@ -90,9 +94,7 @@ class PBuddy:
 
     def ripe_vrp_check(self, asn, pfx):
         """check ASN and prefixies ROA validation"""
-        url = (
-            f"https://stat.ripe.net/data/rpki-validation/data.json?resource={asn}&prefix={pfx}"
-        )
+        url = f"https://stat.ripe.net/data/rpki-validation/data.json?resource={asn}&prefix={pfx}"
         with requests.Session() as session:
             response = session.get(url)
         if response.status_code == 200:
@@ -214,9 +216,7 @@ class PBuddy:
 
     def ripe_asn_announces_consistency(self, asn):
         """check ASN announces consistence"""
-        url = (
-            f"https://stat.ripe.net/data/as-routing-consistency/data.json?resource=AS{asn}"
-        )
+        url = f"https://stat.ripe.net/data/as-routing-consistency/data.json?resource=AS{asn}"
         with requests.Session() as session:
             response = session.get(url)
         if response.status_code == 200:
@@ -549,9 +549,7 @@ class PBuddy:
         """
         expand ASN as-set => work only with RIPE sources/resources, need to improve it
         """
-        url = (
-            f"https://rest.db.ripe.net/search.json?query-string={asset}&type-filter=as-set&flags=no-referenced&flags=no-irt"
-        )
+        url = f"https://rest.db.ripe.net/search.json?query-string={asset}&type-filter=as-set&flags=no-referenced&flags=no-irt"
         with requests.Session() as session:
             response = session.get(url)
         if response.status_code == 200:
@@ -869,7 +867,7 @@ class PBuddy:
                             apl = len(attributenoprep.split())
                         if apl >= int(threshold):
                             entry = (
-                                f'{ris:<{msize}}',
+                                f"{ris:<{msize}}",
                                 " | ",
                                 pfx,
                                 " | ",
@@ -985,7 +983,7 @@ class PBuddy:
         transit,
         direct,
     ):
-        """ create aspath summary """
+        """create aspath summary"""
         locations = []
         for item in tuple_lpa:
             print("".join(map(str, item)))

--- a/peering_buddy.py
+++ b/peering_buddy.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# pylint: disable=too-many-locals, too-many-branches, too-many-statements, line-too-long
+# pylint: disable=too-many-locals, too-many-branches, too-many-statements, line-too-long, unnecessary-lambda-assignment
 # noqa: E501
 """
 Peering Buddy - Helping you dig data from internet for better decisions!
@@ -14,11 +14,14 @@ from pbuddy.pbuddy import PBuddy
 
 def main():
     """Peering Buddy main"""
+    formatter = lambda prog: argparse.HelpFormatter(prog, max_help_position=88)
     parser = argparse.ArgumentParser(
-        description="Peering Buddy - Helping you dig data from internet for better decisions!"
+        description="Peering Buddy - Helping you dig data from internet for better decisions!",
+        formatter_class=formatter,
     )
     parser.add_argument(
         "-av",
+        "--asn-visibility",
         action="store",
         dest="asn_visibility",
         metavar="ASN",
@@ -26,6 +29,7 @@ def main():
     )
     parser.add_argument(
         "-ap",
+        "--asn-announced-pfxs",
         action="store",
         dest="asn_announcedpfxs",
         metavar="ASN",
@@ -33,6 +37,7 @@ def main():
     )
     parser.add_argument(
         "-ar",
+        "--asn-roa-validation",
         action="store",
         dest="asn_roavalidation",
         metavar="ASN",
@@ -40,6 +45,7 @@ def main():
     )
     parser.add_argument(
         "-lg",
+        "--looking-glass",
         action="store",
         dest="pfx_rislg",
         metavar="PREFIX",
@@ -47,6 +53,7 @@ def main():
     )
     parser.add_argument(
         "-al",
+        "--aspath-length-overview",
         action="store",
         dest="asn_aspathoverview",
         metavar="ASN",
@@ -54,6 +61,7 @@ def main():
     )
     parser.add_argument(
         "-as",
+        "--aspath-lenghth-stripped",
         action="store",
         dest="asn_aspathstripped",
         metavar="ASN",
@@ -61,6 +69,7 @@ def main():
     )
     parser.add_argument(
         "-au",
+        "--aspath-lenghth-unstripped",
         action="store",
         dest="asn_aspathunstripped",
         metavar="ASN",
@@ -68,6 +77,7 @@ def main():
     )
     parser.add_argument(
         "-tm",
+        "--threshold-max",
         action="store",
         dest="asn_aspaththresholdmax",
         metavar="INTEGER",
@@ -75,6 +85,7 @@ def main():
     )
     parser.add_argument(
         "-ti",
+        "--threshold-min",
         action="store",
         dest="asn_aspaththresholdmin",
         metavar="INTEGER",
@@ -82,6 +93,7 @@ def main():
     )
     parser.add_argument(
         "-ta",
+        "--threshold-avg",
         action="store",
         dest="asn_aspaththresholdavg",
         metavar="INTEGER",
@@ -89,6 +101,7 @@ def main():
     )
     parser.add_argument(
         "-ao",
+        "--asn-overview",
         action="store",
         dest="asn_overview",
         metavar="ASN",
@@ -96,6 +109,7 @@ def main():
     )
     parser.add_argument(
         "-ac",
+        "--asn-announce-consistency",
         action="store",
         dest="asn_announcesconsistency",
         metavar="ASN",
@@ -103,6 +117,7 @@ def main():
     )
     parser.add_argument(
         "-pa",
+        "--asn-pfxs-aspath-length",
         action="store",
         dest="asn_asnpfxaspathlength",
         metavar=("ASN", "THRESHOLD", "PREPEND[y|n]"),
@@ -111,14 +126,15 @@ def main():
     )
     parser.add_argument(
         "-tu",
+        "--asn-upstreams-transient",
         action="store",
         dest="asn_upstreamtransient",
         metavar="ASN",
         help="[RIPE][BGPView] Check ASN upstreams on transient paths.",
     )
-    # HERE
     parser.add_argument(
         "-gu",
+        "--asn-upstreams",
         action="store",
         dest="upstreams",
         metavar="ASN",
@@ -126,6 +142,7 @@ def main():
     )
     parser.add_argument(
         "-gd",
+        "--asn-downstreams",
         action="store",
         dest="downstreams",
         metavar="ASN",
@@ -133,6 +150,7 @@ def main():
     )
     parser.add_argument(
         "-gw",
+        "--whois",
         action="store",
         dest="whois",
         metavar="[ASN|PREFIX]",
@@ -140,6 +158,7 @@ def main():
     )
     parser.add_argument(
         "-wi",
+        "--whois-ip",
         action="store",
         dest="ipwhois",
         metavar="IP",
@@ -147,16 +166,22 @@ def main():
     )
     parser.add_argument(
         "-aa",
+        "--asset",
         action="store",
         dest="asset",
         metavar="ASN",
         help="[PeeringDB][RIPE] Check ASN AS-SET and expand it. Limited to RIPE ASNs.",
     )
     parser.add_argument(
-        "-ip", action="store_true", help="[PeeringDB] Get IXPs prefixes."
+        "-ip",
+        "--pdb-ixp-pfxs",
+        action="store_true",
+        dest="pdb_ip",
+        help="[PeeringDB] Get IXPs prefixes.",
     )
     parser.add_argument(
         "-ai",
+        "--pdb-asn-info",
         action="store",
         dest="asninfo",
         metavar="ASN",
@@ -164,6 +189,7 @@ def main():
     )
     parser.add_argument(
         "-ii",
+        "--pdb-asn-ips",
         action="store",
         dest="ixpips",
         metavar="ASN",
@@ -171,6 +197,7 @@ def main():
     )
     parser.add_argument(
         "-gc",
+        "--pdb-asn-contact",
         action="store",
         dest="asncontact",
         metavar="ASN",
@@ -178,6 +205,7 @@ def main():
     )
     parser.add_argument(
         "-cc",
+        "--pdb-ixp-bycc",
         action="store",
         dest="ixpcc",
         metavar="ASN",
@@ -185,35 +213,42 @@ def main():
     )
     parser.add_argument(
         "-gl",
+        "--lgs",
         action="store_true",
+        dest="lgs",
         help="[Team Cymrus] Check a list of public LookingGlass.",
     )
     parser.add_argument(
         "-bo",
+        "--bogons",
         action="store_true",
         dest="bogonspfx4",
         help="[Team Cymrus] Get ip4 bogons list.",
     )
     parser.add_argument(
         "-b4",
+        "--bogons-v4",
         action="store_true",
         dest="fbogonspfx4",
         help="[Team Cymrus] Get ip4 full (+unallocated) bogons list.",
     )
     parser.add_argument(
         "-b6",
+        "--bogons-v6",
         action="store_true",
         dest="fbogonspfx6",
         help="[Team Cymrus] Get ip6 full (+unallocated) bogons list.",
     )
     parser.add_argument(
         "-ba",
+        "--bogons-asn",
         action="store_true",
         dest="bogonsasn",
         help="[NTT] Get ASN bogons list/examples.",
     )
     parser.add_argument(
         "-nv",
+        "--non-verbose",
         action="store_true",
         dest="nonverbose",
         help="Remove human-like text to the output.",
@@ -441,7 +476,7 @@ def main():
             print("".join(map(str, item)))
         if args.nonverbose is False:
             print(separator)
-    if args.gl is True:
+    if args.lgs is True:
         result = pbuddy.tc_public_lg()
         if args.nonverbose is False:
             print(separator)
@@ -466,7 +501,7 @@ def main():
         print(json.dumps(expanded, indent=4))
         if args.nonverbose is False:
             print(separator)
-    if args.ip is True:
+    if args.pdb_ip is True:
         if args.nonverbose is False:
             print(separator)
             print("=> IXPs prefixes:")


### PR DESCRIPTION
Adding long arguments and updating readme.

```
% ./peering_buddy.py
usage: peering_buddy.py [-h] [-av ASN] [-ap ASN] [-ar ASN] [-lg PREFIX] [-al ASN] [-as ASN] [-au ASN] [-tm INTEGER] [-ti INTEGER] [-ta INTEGER] [-ao ASN] [-ac ASN] [-pa ASN THRESHOLD PREPEND[y|n]] [-tu ASN] [-gu ASN] [-gd ASN] [-gw [ASN|PREFIX]] [-wi IP]
                        [-aa ASN] [-ip] [-ai ASN] [-ii ASN] [-gc ASN] [-cc ASN] [-gl] [-bo] [-b4] [-b6] [-ba] [-nv]

Peering Buddy - Helping you dig data from internet for better decisions!

optional arguments:
  -h, --help                                                                           show this help message and exit
  -av ASN, --asn-visibility ASN                                                        [RIPE] Check ASN visibility RIPE RIS sensors.
  -ap ASN, --asn-announced-pfxs ASN                                                    [RIPE] Check ASN announced prefixes to internet.
  -ar ASN, --asn-roa-validation ASN                                                    [RIPE] Check ASN RPKI/ROA validation for announced prefixes.
  -lg PREFIX, --looking-glass PREFIX                                                   [RIPE] Get prefix using RIPE RIS as Looking Glass.
  -al ASN, --aspath-length-overview ASN                                                [RIPE] Check AS-Path length overview.
  -as ASN, --aspath-lenghth-stripped ASN                                               [RIPE] Check AS-Path length stripped [no as-prepend].
  -au ASN, --aspath-lenghth-unstripped ASN                                             [RIPE] Check AS-Path length unstripped [with as-prepend].
  -tm INTEGER, --threshold-max INTEGER                                                 [RIPE][as|au] Threshold [>=] to be used with -as and -au for max.
  -ti INTEGER, --threshold-min INTEGER                                                 [RIPE][as|au] Threshold [>=] to be used with -as and -au for min.
  -ta INTEGER, --threshold-avg INTEGER                                                 [RIPE][as|au] Threshold [>=] to be used with -as and -au for avg.
  -ao ASN, --asn-overview ASN                                                          [RIPE] Check ASN public resources overview.
  -ac ASN, --asn-announce-consistency ASN                                              [RIPE][BGPView][IPInfo] Check ASN announces consistency.
  -pa ASN THRESHOLD PREPEND[y|n], --asn-pfxs-aspath-length ASN THRESHOLD PREPEND[y|n]  [RIPE][BGPView] Check ASN prefixes where as-path length >= threshold.
  -tu ASN, --asn-upstreams-transient ASN                                               [RIPE][BGPView] Check ASN upstreams on transient paths.
  -gu ASN, --asn-upstreams ASN                                                         [BGPView] Get ASN upstreams.
  -gd ASN, --asn-downstreams ASN                                                       [BGPView] Get ASN downstreams.
  -gw [ASN|PREFIX], --whois [ASN|PREFIX]                                               [BGPView] Get ASN/Prefix whois information.
  -wi IP, --whois-ip IP                                                                [IPInfo] Get IP whois information.
  -aa ASN, --asset ASN                                                                 [PeeringDB][RIPE] Check ASN AS-SET and expand it. Limited to RIPE ASNs.
  -ip, --pdb-ixp-pfxs                                                                  [PeeringDB] Get IXPs prefixes.
  -ai ASN, --pdb-asn-info ASN                                                          [PeeringDB] Get ASN information on PeeringDB.
  -ii ASN, --pdb-asn-ips ASN                                                           [PeeringDB] Get ASN IPS allocated on IXPs.
  -gc ASN, --pdb-asn-contact ASN                                                       [PeeringDB] Get ASN contact.
  -cc ASN, --pdb-ixp-bycc ASN                                                          [PeeringDB] Get IXPs by Country Code [iso-3166-1 alpha-2].
  -gl, --lgs                                                                           [Team Cymrus] Check a list of public LookingGlass.
  -bo, --bogons                                                                        [Team Cymrus] Get ip4 bogons list.
  -b4, --bogons-v4                                                                     [Team Cymrus] Get ip4 full (+unallocated) bogons list.
  -b6, --bogons-v6                                                                     [Team Cymrus] Get ip6 full (+unallocated) bogons list.
  -ba, --bogons-asn                                                                    [NTT] Get ASN bogons list/examples.
  -nv, --non-verbose                                                                   Remove human-like text to the output.
  ```